### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-fishspeech"
+description = "a custom comfyui node for [a/fish-speech](https://github.com/fishaudio/fish-speech.git)"
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["transformers>=4.35.2", "datasets>=2.14.5", "lightning>=2.1.0", "hydra-core>=1.3.2", "tensorboard>=2.14.1", "natsort>=8.4.0", "einops>=0.7.0", "librosa>=0.10.1", "rich>=13.5.3", "wandb>=0.15.11", "grpcio>=1.58.0", "kui>=1.6.0", "zibai-server>=0.9.0", "loguru>=0.6.0", "loralib>=0.1.2", "natsort>=8.4.0", "pyrootutils>=1.0.4", "vector_quantize_pytorch>=1.14.7", "resampy>=0.4.3", "einx[torch]==0.2.2", "srt", "pydub", "audiotsm"]
+
+[project.urls]
+Repository = "https://github.com/AIFSH/ComfyUI-FishSpeech"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-FishSpeech"
+Icon = ""


### PR DESCRIPTION
We are working with dr.lt.data and comfyanon to build a global registry for custom nodes (similar to PyPI). Eventually, the registry will be used as a backend for the UI-manager. All nodes go through a verification process before being published to users.

The main benefits are that authors can
- publish nodes by version and users can safely update nodes knowing ahead of time if their workflows will break or not
- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id. Add the publisher id into the pyproject.toml file.
- [ ] Write a short description.
- [ ] Merge the separate Github Actions PR and run the workflow.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`

Check out our [docs](https://docs.comfy.org/registry/overview#introduction) if you want to know more about the registry. Otherwise, feel free to message me on discord at haohao_81202 or join our [server](https://discord.com/invite/comfyorg) if you have any questions!